### PR TITLE
fix: resolve uneven weather metric card bug

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -178,7 +178,7 @@ export default function WeatherPage() {
                         {isWeatherLoading ? (
                             <LoadingSkeleton />
                         ) : weatherData ? (
-                            <div className="space-y-6 mt-8">
+                            <div className="space-y-6 mt-8 flex flex-col gap-5">
                                 {/* Hero Section */}
                                 <WeatherHero weatherData={weatherData} />
 

--- a/components/weather/WeatherMetrics.tsx
+++ b/components/weather/WeatherMetrics.tsx
@@ -45,7 +45,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
     };
 
     return (
-        <Card className="!bg-white/10 !border-white/20 backdrop-blur-lg hover:!bg-white/15 transition-all duration-300 hover:scale-105 hover:shadow-xl">
+        <Card className="!bg-white/10 !border-white/20 backdrop-blur-lg hover:!bg-white/15 transition-all duration-300 hover:scale-105 hover:shadow-xl h-full">
             <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center space-x-3">
                     <div className="p-2 bg-white/20 rounded-lg">{icon}</div>


### PR DESCRIPTION
Fixed inconsistent height of the Apparent Temperature
![Before](https://github.com/user-attachments/assets/83381d76-e584-42cb-91c7-028d04c0c2c6)
 card in the Weather Metrics section.